### PR TITLE
Fix for wrong root directory detection

### DIFF
--- a/plugin/src/net/groboclown/idea/p4ic/v2/server/cache/sync/FileActionsServerCacheSync.java
+++ b/plugin/src/net/groboclown/idea/p4ic/v2/server/cache/sync/FileActionsServerCacheSync.java
@@ -1476,6 +1476,15 @@ public class FileActionsServerCacheSync extends CacheFrontEnd {
             LOG.debug("Symlink 1: Mapped paths " + currentKnownDepotPaths);
         }
 
+        // Retrieve depot root path as it may be different with project base dir.
+        FilePath depotRootPath = FilePathUtil.getFilePath(exec.getClient().getRoot());
+        VirtualFile depotRootDir = null;
+        if (depotRootPath != null) {
+            depotRootDir = FilePathUtil.getFilePath(exec.getClient().getRoot()).getVirtualFile();
+        }
+        if (depotRootDir == null) {
+            depotRootDir = exec.getProject().getBaseDir();
+        }
 
         // There may be multiple symlinks pointing to symlinks, so we need to loop until we've
         // exhausted the list of files that have symlinks.
@@ -1483,7 +1492,7 @@ public class FileActionsServerCacheSync extends CacheFrontEnd {
         do {
             // Find the complete list of parent directories for the requested files for add, up to but not including
             // the depot.  So, a file like //depot/a/b/c.txt would have //depot/a, //depot/a/b as the returned list.
-            List<IFileSpec> splitParents = splitParentPathsFor(exec.getProject().getBaseDir(), remainingFilesNeedingMaps);
+            List<IFileSpec> splitParents = splitParentPathsFor(depotRootDir, remainingFilesNeedingMaps);
 
             // Run p4 fstat "-F "headType = symlink" (split parents list)
             // Returns only the paths that are symlinks.


### PR DESCRIPTION
I have an issue with Android Studio.

Perforce config:
Workspace: workspace_Basic
Root: /Users/Aleksey/workspace_Basic/
View mapping: //depot/project/... //workspace_Basic/project/...

Plugin config:
VCS Directory: /Users/Aleksey/workspace_Basic/
Specific Configuration File: /Users/Aleksey/workspace_Basic/p4_properties.txt // P4PORT, P4USER, P4CLIENT

Folders structure: 
Users
|   +-- Aleksey
|   |   +-- workspace_Basic
|   |   |   +-- p4_properties.txt
|   |   |   +-- project
|   |   |   |   +-- Lib_A 
|   |   |   |   |   +-- build.gradle
|   |   |   |   |   +-- settings.gradle
|   |   |   |   |   +-- src
|   |   |   |   |   |   +-- classLibA.java
|   |   |   |   +-- Lib_B (gradle module)
|   |   |   |   |   +-- build.gradle
|   |   |   |   |   +-- settings.gradle
|   |   |   |   |   +-- src
|   |   |   |   |   |   +-- classLibB.java
|   |   |   |   +-- App
|   |   |   |   |   +-- .idea
|   |   |   |   |   +-- build.gradle
|   |   |   |   |   +-- settings.gradle
|   |   |   |   |   +-- src
|   |   |   |   |   |   +-- classApp.java

Module "App" includes "Lib_A" and "Lib_B" via gradle. So in one Android Studio workspace I can modify files from all modules ("App", "Lib_A", "Lib_B").

I can successfully add "App/src/classApp.java" to a ChangeList.
But when I try to add "Lib_A/src/classLibA.java" to the same CL it throws an error:
_Path '/Users/Aleksey/' is not under client's root '/Users/Aleksey/workspace_Basic/'_

After a small investigation I find the difference between "Lib_A" and "App".

Checked paths for "App":
/Users/Aleksey/workspace_Basic/project/App
/Users/Aleksey/workspace_Basic/project/App/src
/Users/Aleksey/workspace_Basic/project/App/src/classApp.java

Checked paths for "Lib_A":
/Users/
/Users/Aleksey/
/Users/Aleksey/workspace_Basic/
/Users/Aleksey/workspace_Basic/project/
/Users/Aleksey/workspace_Basic/project/Lib_A
/Users/Aleksey/workspace_Basic/project/Lib_A/src
/Users/Aleksey/workspace_Basic/project/Lib_A/src/classApp.java

Place where error occurs - net.groboclown.idea.p4ic.v2.server.cache.sync.FileActionsServerCacheSync.java

// Find the complete list of parent directories for the requested files for add, up to but not including
// the depot.  So, a file like //depot/a/b/c.txt would have //depot/a, //depot/a/b as the returned list.
List<IFileSpec> splitParents = splitParentPathsFor(exec.getProject().getBaseDir(), remainingFilesNeedingMaps);

exec.getProject().getBaseDir() - returns a directory where .idea or .ipr exists. 

In my case exec.getProject().getBaseDir() returns /Users/Aleksey/workspace_Basic/project/App.
As "/Users/Aleksey/workspace_Basic/project/Lib_A/src/classApp.java" is not under "/Users/Aleksey/workspace_Basic/project/App"  _splitParentPathsFor()_ returns all folders up to "Users/"


As a fix an actual workspace root folder should be used to check if file is under client's root.

